### PR TITLE
Update str to nccl bfloat16 dtype for parsing RCCL/NCCL configurations. 

### DIFF
--- a/rccl_nccl_parser.py
+++ b/rccl_nccl_parser.py
@@ -34,7 +34,7 @@ data_types_map = {
                 "6" : "half",
                 "7" : "float",
                 "8" : "double",
-                "9" : "bf16",
+                "9" : "bfloat16",
                 #"10" : "ncclNumTypes Equivalent?"
              }
 


### PR DESCRIPTION
The string value needs to be updated from bf16 to bfloat16 to be able to pick ncclBfloat16 type 